### PR TITLE
Update for Symphony 2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.markdown
+++ b/README.markdown
@@ -2,9 +2,9 @@
 
 "Just in time" SASS compiler for Symphony CMS.
 
-- Version: 1.0
-- Date: 2nd February 2013
-- Requirements: Symphony 2.3 or later
+- Version: 1.1
+- Date: 5th July 2015
+- Requirements: Symphony 2.6 or later
 - Author: Nils Werner, nils.werner@gmail.com
 - GitHub Repository: <http://github.com/nils-werner/sass_compiler>
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -5,8 +5,8 @@
 		public function about(){
 			return array(
 				'name' => 'SASS Compiler',
-				'version' => '1.0',
-				'release-date' => '2013-02-02',
+				'version' => '1.1',
+				'release-date' => '2015-07-05',
 				'author' => array(
 					array(
 						'name' => 'Nils Werner',
@@ -36,7 +36,7 @@
 	RewriteRule ^sass\/(.+\.sass)\$ extensions/sass_compiler/lib/sass.php?mode=sass&param={$token} [L,NC]
 	RewriteRule ^scss\/(.+\.scss)\$ extensions/sass_compiler/lib/sass.php?mode=scss&param={$token} [L,NC]\n\n";
 
-			## Remove existing the rules
+			## Remove existing rules
 			$htaccess = self::__removeSassRules($htaccess);
 
 			if(preg_match('/### SASS RULES/', $htaccess)){

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -15,7 +15,7 @@
 	<media>
 	</media>
 	<releases>
-		<release version="1.1" date="2015-07-05" min="2.6.0">
+		<release version="1.1" date="2015-07-05" min="2.6">
 			Initial Release
 		</release>
 	</releases>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -16,6 +16,9 @@
 	</media>
 	<releases>
 		<release version="1.1" date="2015-07-05" min="2.6">
+			Symphony 2.6 compatibility
+		</release>
+		<release version="1.0" date="2013-02-02" min="2.3" max="2.5.3">
 			Initial Release
 		</release>
 	</releases>

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -15,7 +15,7 @@
 	<media>
 	</media>
 	<releases>
-		<release version="1.0" date="2013-02-02" min="2.3">
+		<release version="1.1" date="2015-07-05" min="2.6.0">
 			Initial Release
 		</release>
 	</releases>

--- a/lib/sass.php
+++ b/lib/sass.php
@@ -6,7 +6,7 @@
 	define('DOMAIN', rtrim(rtrim($_SERVER['HTTP_HOST'], '/') . str_replace('/extensions/sass_compiler/lib', NULL, dirname($_SERVER['PHP_SELF'])), '/'));
 
 	// Include some parts of the engine
-	require_once(DOCROOT . '/symphony/lib/boot/bundle.php');
+	require_once(DOCROOT . '/vendor/autoload.php');
 	require_once(CONFIG);
 	
 	require_once('dist/SassParser.php');


### PR DESCRIPTION
I updated `sass.php` and also added the entire `dist` folder. Some people complained that it was missing in the initial release or that it had to be pulled from another repository.

This release will work with Symphony 2.6 and higher, but not with previous versions. I tried to adjust all meta files accordingly.
