### PR TITLE
Change Docs to reflect the need to pull the assoiated submodule

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,8 +2,8 @@
 
 "Just in time" SASS compiler for Symphony CMS.
 
-- Version: 1.1
-- Date: 5th July 2015
+- Version: 1.1.1
+- Date: 27th February 2018
 - Requirements: Symphony 2.6 or later
 - Author: Nils Werner, nils.werner@gmail.com
 - GitHub Repository: <http://github.com/nils-werner/sass_compiler>
@@ -14,7 +14,11 @@ A simple way to compile SASS and SCSS files on the fly via the URL.
 
 ## Installation
 
-Information about [installing and updating extensions](http://symphony-cms.com/learn/tasks/view/install-an-extension/) can be found in the Symphony documentation at <http://symphony-cms.com/learn/>.
+This extension maks use of the [Sass Parser](https://github.com/richthegeek/phpsass/) as a submodule
+
+If downloading through Git use the command: git clone --recursive https://github.com/nils-werner/sass_compiler.git
+Information about Git [submodules](https://www.getsymphony.com/learn/articles/view/on-git-submodules/) can be found in the Symphony documentation at <https://www.getsymphony.com/learn>.
+
 
 ## Usage
 

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -4,9 +4,9 @@
 
 		public function about(){
 			return array(
-				'name' => 'SASS Compiler',
-				'version' => '1.1',
-				'release-date' => '2015-07-05',
+					'name' => 'SASS Compiler',
+				'version' => '1.1.1',
+				'release-date' => '2018-02-27',
 				'author' => array(
 					array(
 						'name' => 'Nils Werner',

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -15,6 +15,9 @@
 	<media>
 	</media>
 	<releases>
+		<release version="1.1.1" date="2018-02-27" min="2.6">
+			Updated Docs with submodule information
+		</release>
 		<release version="1.1" date="2015-07-05" min="2.6">
 			Symphony 2.6 compatibility
 		</release>


### PR DESCRIPTION
This is an update to the readme file refering the correct way to clone this repo taking into consideration the  submodule in it. Without this info by doing a normal git clone or even using the Symphony CMS extension manager, the extension will not work properly and provide no errors as to what is happening.